### PR TITLE
extract goat player functionality to  scene

### DIFF
--- a/goat/main_scenes/GoatPlayer.gd
+++ b/goat/main_scenes/GoatPlayer.gd
@@ -1,0 +1,60 @@
+extends Spatial
+
+onready var ray_cast = get_parent().get_node("Camera/RayCast3D")
+onready var inventory = $Inventory
+onready var context_inventory = $ContextInventory
+onready var settings = $Settings
+onready var scope = $Scope
+
+
+func _ready():
+	inventory.hide()
+	context_inventory.hide()
+	settings.hide()
+	
+	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+	update_scope_visibility()
+
+	goat.connect("game_mode_changed", self, "_on_game_mode_changed")
+	goat_settings.connect(
+		"value_changed_gui_scope", self, "_on_scope_settings_changed"
+	)
+
+func _input(event):
+	if goat.game_mode != goat.GameMode.EXPLORING:
+		return
+	
+	if Input.is_action_just_pressed("goat_toggle_inventory"):
+		goat.game_mode = goat.GameMode.INVENTORY
+		get_parent().deactivate()
+	
+	if Input.is_action_just_pressed("goat_dismiss"):
+		goat.game_mode = goat.GameMode.SETTINGS
+
+func update_scope_visibility():
+	scope.visible = (
+		goat.game_mode == goat.GameMode.EXPLORING and
+		goat_settings.get_value("gui", "scope")
+	)
+
+func _on_game_mode_changed(new_game_mode):
+	var exploring_mode = new_game_mode == goat.GameMode.EXPLORING
+	var inventory_mode = new_game_mode == goat.GameMode.INVENTORY
+	var settings_mode = new_game_mode == goat.GameMode.SETTINGS
+	var context_inventory_mode = new_game_mode == goat.GameMode.CONTEXT_INVENTORY
+	scope.visible = exploring_mode
+	ray_cast.enabled = exploring_mode
+	
+	update_scope_visibility()
+	var camera = get_viewport().get_camera()
+	camera.environment.dof_blur_far_enabled = inventory_mode
+	
+	if exploring_mode:
+		get_parent().activate()
+		Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+
+	if settings_mode or context_inventory_mode:
+		get_parent().deactivate()
+
+func _on_scope_settings_changed():
+	update_scope_visibility()

--- a/goat/main_scenes/GoatPlayer.tscn
+++ b/goat/main_scenes/GoatPlayer.tscn
@@ -1,0 +1,74 @@
+[gd_scene load_steps=12 format=2]
+
+[ext_resource path="res://goat/helper_scenes/ContextInventory.gd" type="Script" id=1]
+[ext_resource path="res://goat/helper_scenes/ContextInventory.tscn" type="PackedScene" id=2]
+[ext_resource path="res://goat/helper_scenes/Settings.tscn" type="PackedScene" id=3]
+[ext_resource path="res://goat/helper_scenes/Settings.gd" type="Script" id=4]
+[ext_resource path="res://goat/helper_scenes/Subtitles.gd" type="Script" id=5]
+[ext_resource path="res://goat/helper_scenes/InventoryBar.gd" type="Script" id=6]
+[ext_resource path="res://goat/helper_scenes/InventoryBar.tscn" type="PackedScene" id=7]
+[ext_resource path="res://goat/helper_scenes/Inventory.gd" type="Script" id=8]
+[ext_resource path="res://goat/main_scenes/GoatPlayer.gd" type="Script" id=9]
+[ext_resource path="res://goat/helper_scenes/Inventory.tscn" type="PackedScene" id=10]
+[ext_resource path="res://goat/helper_scenes/Subtitles.tscn" type="PackedScene" id=11]
+
+[node name="GoatPlayer" type="Spatial"]
+script = ExtResource( 9 )
+
+[node name="Scope" type="Label" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -2.0
+margin_top = -7.0
+margin_right = 2.0
+margin_bottom = 7.0
+text = "·"
+align = 1
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="InventoryBar" type="Control" parent="." instance=ExtResource( 7 )]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 6 )
+
+[node name="Inventory" type="Control" parent="." instance=ExtResource( 10 )]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 1
+script = ExtResource( 8 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ContextInventory" type="Control" parent="." instance=ExtResource( 2 )]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Subtitles" type="Control" parent="." instance=ExtResource( 11 )]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_bottom = -10.0
+mouse_filter = 2
+script = ExtResource( 5 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Settings" type="CenterContainer" parent="." instance=ExtResource( 3 )]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 4 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+[connection signal="resized" from="Inventory" to="Inventory" method="_on_Inventory_resized"]

--- a/goat/main_scenes/Player.gd
+++ b/goat/main_scenes/Player.gd
@@ -6,25 +6,9 @@ export (float) var SPEED = 3.0
 var movement_direction = Vector3()
 
 onready var camera = $Camera
-onready var ray_cast = $Camera/RayCast3D
-onready var inventory = $Inventory
-onready var context_inventory = $ContextInventory
-onready var settings = $Settings
-onready var scope = $Scope
 
 
 func _ready():
-	inventory.hide()
-	context_inventory.hide()
-	settings.hide()
-	update_scope_visibility()
-	
-	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
-	
-	goat.connect("game_mode_changed", self, "_on_game_mode_changed")
-	goat_settings.connect(
-		"value_changed_gui_scope", self, "_on_scope_settings_changed"
-	)
 	# Make sure that the Player is standing on the ground
 	move_and_collide(Vector3(0, -100, 0))
 
@@ -92,25 +76,10 @@ func update_movement_direction():
 	movement_direction.y = 0
 	movement_direction = movement_direction.normalized()
 
+func deactivate():
+	set_physics_process(false)
+	set_process_input(false)
 
-func update_scope_visibility():
-	scope.visible = (
-		goat.game_mode == goat.GameMode.EXPLORING and
-		goat_settings.get_value("gui", "scope")
-	)
-
-
-func _on_game_mode_changed(new_game_mode):
-	var exploring_mode = new_game_mode == goat.GameMode.EXPLORING
-	var inventory_mode = new_game_mode == goat.GameMode.INVENTORY
-	
-	update_scope_visibility()
-	ray_cast.enabled = exploring_mode
-	camera.environment.dof_blur_far_enabled = inventory_mode
-	
-	if exploring_mode:
-		Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
-
-
-func _on_scope_settings_changed():
-	update_scope_visibility()
+func activate():
+	set_physics_process(true)
+	set_process_input(true)

--- a/goat/main_scenes/Player.tscn
+++ b/goat/main_scenes/Player.tscn
@@ -1,13 +1,9 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://goat/main_scenes/Player.gd" type="Script" id=1]
 [ext_resource path="res://goat/environments/default_environment.tres" type="Environment" id=2]
 [ext_resource path="res://goat/helper_scenes/RayCast3D.tscn" type="PackedScene" id=3]
-[ext_resource path="res://goat/helper_scenes/InventoryBar.tscn" type="PackedScene" id=4]
-[ext_resource path="res://goat/helper_scenes/Inventory.tscn" type="PackedScene" id=5]
-[ext_resource path="res://goat/helper_scenes/ContextInventory.tscn" type="PackedScene" id=6]
-[ext_resource path="res://goat/helper_scenes/Subtitles.tscn" type="PackedScene" id=7]
-[ext_resource path="res://goat/helper_scenes/Settings.tscn" type="PackedScene" id=8]
+[ext_resource path="res://goat/main_scenes/GoatPlayer.tscn" type="PackedScene" id=4]
 
 [sub_resource type="CylinderShape" id=1]
 radius = 0.3
@@ -31,25 +27,4 @@ enabled = true
 cast_to = Vector3( 0, 0, -2 )
 category = "environment"
 
-[node name="Scope" type="Label" parent="."]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -2.0
-margin_top = -7.0
-margin_right = 2.0
-margin_bottom = 7.0
-text = "·"
-align = 1
-valign = 1
-
-[node name="InventoryBar" parent="." instance=ExtResource( 4 )]
-
-[node name="Inventory" parent="." instance=ExtResource( 5 )]
-
-[node name="ContextInventory" parent="." instance=ExtResource( 6 )]
-
-[node name="Subtitles" parent="." instance=ExtResource( 7 )]
-
-[node name="Settings" parent="." instance=ExtResource( 8 )]
+[node name="GoatPlayer" parent="." instance=ExtResource( 4 )]


### PR DESCRIPTION
Hi, I'm using Goat in my new game and how I said  you in twitter (https://twitter.com/sergi_py/status/1248573245546209280?s=20) I think this changes could be useful for more people.

I've extracted goat player functionality to another scene without player movement logical so now users can get it and append to their own player entity creating activate an deactivate methods.

It would be better uncoupling raycast, maybe adding a export parameter in goatPlayer node in order to can select  raycast node from ui.

thanks!
