### PR TITLE
Add inventory items to editor

### DIFF
--- a/addons/goat/main_scenes/InteractiveItem.gd
+++ b/addons/goat/main_scenes/InteractiveItem.gd
@@ -33,6 +33,10 @@ const COLLISION_MASK_LAYER = 2
 var _orig_cast_shadow_settings = {}
 
 func _ready():
+	# GOAT main screen shows a list of inventory items: interactive items are currently inactive there
+	if Engine.is_editor_hint():
+		return
+	
 	if ("_activated_" + unique_name) in goat_state._variables and item_type == ItemType.INVENTORY:
 		queue_free()
 		return

--- a/addons/goat/main_screen/goat_main_screen.tscn
+++ b/addons/goat/main_screen/goat_main_screen.tscn
@@ -1,4 +1,6 @@
-[gd_scene format=3 uid="uid://06esj32ky2yf"]
+[gd_scene load_steps=2 format=3 uid="uid://06esj32ky2yf"]
+
+[ext_resource type="PackedScene" uid="uid://ci6ngr1cckxxd" path="res://addons/goat/main_screen/inventory_main_screen.tscn" id="1_6ka4w"]
 
 [node name="GOATMainScreen" type="Control"]
 layout_mode = 3
@@ -17,10 +19,12 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+current_tab = 0
 
 [node name="Dialogues" type="VBoxContainer" parent="TabContainer" groups=["goat_dialogue_manager_container"]]
 unique_name_in_owner = true
 layout_mode = 2
+metadata/_tab_index = 0
 
 [node name="DialogueManagerCredits" type="HBoxContainer" parent="TabContainer/Dialogues"]
 custom_minimum_size = Vector2(0, 40)
@@ -40,3 +44,8 @@ size_flags_horizontal = 4
 size_flags_vertical = 4
 text = "Dialogue Manager"
 uri = "https://github.com/nathanhoad/godot_dialogue_manager"
+
+[node name="Inventory" parent="TabContainer" instance=ExtResource("1_6ka4w")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 1

--- a/addons/goat/main_screen/inventory_main_screen.gd
+++ b/addons/goat/main_screen/inventory_main_screen.gd
@@ -1,0 +1,37 @@
+@tool
+extends Control
+
+
+func _ready() -> void:
+	refresh_items()
+
+
+func refresh_items():
+	var items = ProjectSettings.get_setting("goat/inventory/items", [])
+	%ItemList.clear()
+	for item in items:
+		var item_name = item.get_file().get_basename()
+		%ItemList.add_item(item_name)
+
+
+func _on_item_list_visibility_changed() -> void:
+	refresh_items()
+
+
+func _on_item_list_item_selected(index: int) -> void:
+	var item_scene_path = ProjectSettings.get_setting("goat/inventory/items", [])[index]
+	if %Pivot.get_child_count() > 0:
+		var current_item_scene = %Pivot.get_child(0)
+		%Pivot.remove_child(current_item_scene)
+		current_item_scene.queue_free()
+	var new_item_scene = load(item_scene_path).instantiate()
+	%Pivot.rotation = Vector3(0, 0, 0)
+	%Pivot.add_child(new_item_scene)
+
+
+func _on_sub_viewport_container_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseMotion and event.button_mask:
+		var angle_horizontal = deg_to_rad(event.relative.x)
+		var angle_vertical = deg_to_rad(event.relative.y)
+		%Pivot.rotate_y(angle_horizontal)
+		%Pivot.rotate_x(angle_vertical)

--- a/addons/goat/main_screen/inventory_main_screen.tscn
+++ b/addons/goat/main_screen/inventory_main_screen.tscn
@@ -1,0 +1,66 @@
+[gd_scene load_steps=3 format=3 uid="uid://ci6ngr1cckxxd"]
+
+[ext_resource type="Script" path="res://addons/goat/main_screen/inventory_main_screen.gd" id="1_kxrxf"]
+[ext_resource type="Environment" uid="uid://dvmrow24o73ah" path="res://addons/goat/environments/inventory_environment.tres" id="2_butog"]
+
+[node name="InventoryMainScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_kxrxf")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ItemList" type="ItemList" parent="HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(300, 0)
+layout_mode = 2
+
+[node name="SubViewportContainer" type="SubViewportContainer" parent="HBoxContainer"]
+custom_minimum_size = Vector2(600, 600)
+layout_mode = 2
+stretch = true
+
+[node name="SubViewport" type="SubViewport" parent="HBoxContainer/SubViewportContainer"]
+own_world_3d = true
+handle_input_locally = false
+size = Vector2i(600, 648)
+render_target_update_mode = 4
+
+[node name="Preview" type="Node3D" parent="HBoxContainer/SubViewportContainer/SubViewport"]
+
+[node name="Camera3D" type="Camera3D" parent="HBoxContainer/SubViewportContainer/SubViewport/Preview"]
+
+[node name="Pivot" type="Node3D" parent="HBoxContainer/SubViewportContainer/SubViewport/Preview"]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2)
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="HBoxContainer/SubViewportContainer/SubViewport/Preview"]
+environment = ExtResource("2_butog")
+
+[node name="Docs" type="RichTextLabel" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+bbcode_enabled = true
+text = "Inventory items can be added in:
+
+[b]Project → Settings → Goat → Inventory → Items[/b]
+
+[i](be sure to enable \"Advanced Settings\")[/i]
+
+Items should be 3D scenes. Each added item will be available during the game by the name of the scene, without the extension (e.g. [b]res://demo/items/abc.tscn[/b] becomes [b]abc[/b]).
+
+Click and drag on the preview to rotate the view."
+
+[connection signal="item_selected" from="HBoxContainer/ItemList" to="." method="_on_item_list_item_selected"]
+[connection signal="visibility_changed" from="HBoxContainer/ItemList" to="." method="_on_item_list_visibility_changed"]
+[connection signal="gui_input" from="HBoxContainer/SubViewportContainer" to="." method="_on_sub_viewport_container_gui_input"]

--- a/addons/goat/plugin.gd
+++ b/addons/goat/plugin.gd
@@ -25,7 +25,7 @@ func _enter_tree():
 	add_autoload_singleton("goat_voice", "res://addons/goat/globals/goat_voice.gd")
 	add_autoload_singleton("goat_settings", "res://addons/goat/globals/goat_settings.gd")
 	
-	main_screen_instance = load("res://addons/goat/globals/goat_main_screen.tscn").instantiate()
+	main_screen_instance = load("res://addons/goat/main_screen/goat_main_screen.tscn").instantiate()
 	get_editor_interface().get_editor_main_screen().add_child(main_screen_instance)
 	_make_visible(false)
 	load_plugins()


### PR DESCRIPTION
A new tab was added to GOAT's main screen: Inventory. It displays the list of all configured inventory items (from ProjectSettings) as well as a 3D preview.

<img width="1367" height="711" alt="Screenshot from 2025-08-18 21-22-58" src="https://github.com/user-attachments/assets/1cd768f1-50ae-4dab-9ebf-3d5bbf970c02" />
<img width="1367" height="711" alt="Screenshot from 2025-08-18 21-22-30" src="https://github.com/user-attachments/assets/210197fd-33e5-4ed0-ae5e-4a6362e811a1" />
